### PR TITLE
handle hash comments

### DIFF
--- a/src/ini.zig
+++ b/src/ini.zig
@@ -159,7 +159,7 @@ fn consume(data: []const u8, seek: *usize, state: *TokenizerState) ?Token {
         switch (state.*) {
             .nil => {
                 switch (char) {
-                    ';' => {
+                    ';', '#' => {
                         state.* = .comment;
                         start = seek.*;
                         if (std.ascii.isSpace(data[start])) start += 1;
@@ -226,7 +226,7 @@ fn consume(data: []const u8, seek: *usize, state: *TokenizerState) ?Token {
             },
             .value => {
                 switch (char) {
-                    ';' => {
+                    ';', '#' => {
                         state.* = .comment;
                         return Token{
                             .kind = .value,

--- a/src/test.ini
+++ b/src/test.ini
@@ -10,5 +10,6 @@ port = 143
 file = payroll.dat
 use = yes
 
+# ini also accepts hash comments
 [withtabs]
     foo = bar


### PR DESCRIPTION
Ini doesn't have a formal standard but while `;` is the preferred comment token many files and parser also use `#` based comments. This PR adds support for such files.